### PR TITLE
Contralto/Properties/Resources.resx: Fix path case

### DIFF
--- a/Contralto/Properties/Resources.resx
+++ b/Contralto/Properties/Resources.resx
@@ -125,7 +125,7 @@
     <value>..\Resources\DiskRead.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="DiskSeek" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\diskseek.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Resources\DiskSeek.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="DiskWrite" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\DiskWrite.bmp;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>


### PR DESCRIPTION
This fixes building on non-Windows.